### PR TITLE
feat: add release workflow to publish Docker image to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-image:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -164,6 +164,30 @@ docker compose down -v
 | Keycloak | `http://localhost:8080` |
 | PostgreSQL | `localhost:5432` |
 
+## CD: Publish Docker image to GHCR
+
+This repository now includes a release workflow in `.github/workflows/release.yml`.
+
+What it does:
+
+- Builds the Docker image from `Dockerfile`.
+- Pushes image to GitHub Container Registry (GHCR):
+  `ghcr.io/<owner>/<repo>`
+- Runs automatically when you push a version tag like `v0.1.0`.
+
+Create and push a release tag:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+After the workflow finishes, pull the image with:
+
+```bash
+docker pull ghcr.io/<owner>/<repo>:v0.1.0
+```
+
 ## Usage
 
 All protected endpoints require a Bearer token from Keycloak. Obtain one first:


### PR DESCRIPTION
This pull request adds automated publishing of Docker images to GitHub Container Registry (GHCR) upon creating a version tag. It introduces a new GitHub Actions workflow for building and pushing Docker images, and updates the documentation to explain the new release process.

**Continuous Deployment & Documentation:**

* Added a new GitHub Actions workflow in `.github/workflows/release.yml` to automatically build and push Docker images to GHCR when a version tag (e.g., `v0.1.0`) is pushed.
* Updated `README.md` with instructions on how the release workflow works, how to tag a release, and how to pull the published Docker image from GHCR.

---

**This is only a DRAFT**