### PR TITLE
51 feat add badges to GitHub repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-![GitHub branch status](https://img.shields.io/github/checks-status/JoMag-Inc/firebuster/main)
+[![CI](https://github.com/JoMag-Inc/firebuster/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/JoMag-Inc/firebuster/actions/workflows/ci.yml)
+[![Docker Publish](https://github.com/JoMag-Inc/firebuster/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/JoMag-Inc/firebuster/actions/workflows/docker-publish.yml)
+[![GitHub release](https://img.shields.io/github/v/release/JoMag-Inc/firebuster)](https://github.com/JoMag-Inc/firebuster/releases)
+[![Python](https://img.shields.io/badge/python-3.13+-3776ab?logo=python&logoColor=white)](https://www.python.org/)
+[![Docker Image](https://img.shields.io/badge/ghcr.io-firebuster-0db7ed?logo=docker&logoColor=white)](https://ghcr.io/jomag-inc/firebuster)
 
 # firebuster
 


### PR DESCRIPTION
This pull request updates the `README.md` file to improve project documentation and its visual presentation. The most notable changes are the addition of status badges for CI, Docker, releases, and supported Python versions, as well as formatting improvements to tables for better readability.

Documentation enhancements:

* Added badges for CI status, Docker publish status, GitHub releases, supported Python version, and Docker image to the top of the `README.md` for improved project visibility and quick status checks.

Release one is not responding for now. Will hopefully work in the future