### PR TITLE
feat: integrate MQTT service for fire-risk event publishing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,16 @@ server_url=http://keycloak:8080
 realm=Firebuster
 
 # ===================================================================
+# MQTT Configuration
+# ===================================================================
+MQTT_BROKER_HOST=mqtt
+MQTT_BROKER_PORT=1883
+MQTT_TOPIC=firebuster/fire-risk
+MQTT_CLIENT_ID=firebuster-api
+MQTT_USERNAME=
+MQTT_PASSWORD=
+
+# ===================================================================
 # PostgreSQL Container Configuration
 # ===================================================================
 POSTGRES_USER=postgres

--- a/app/factory.py
+++ b/app/factory.py
@@ -5,6 +5,7 @@ from sqlalchemy.engine import Engine
 from sqlmodel import Session
 from decouple import config
 
+from app.services.mqtt.mqtt_service import MQTTService
 from app.repositories.ttf.ttf_repository import PostgresTTFRepository
 from app.services.ttf.ttf_service import TTFService
 from app.services.weather.weather_service import WeatherService
@@ -12,18 +13,36 @@ from app.services.weather import weather_static
 
 
 class ServiceFactory:
-    def __init__(self, database_url: str, weather_config: dict):
+    def __init__(self, database_url: str, service_config: dict):
         self.engine: Engine = create_engine(database_url)
-        self.weather_service = WeatherService(
-            base_url=weather_config["base_url"],
-            headers=weather_config["headers"],
-            timeout=weather_config["timeout"],
+        self.weather_service = self._build_weather_service(service_config)
+        self.mqtt_service = self._build_mqtt_service(service_config)
+
+    def _build_weather_service(self, service_config: dict) -> WeatherService:
+        return WeatherService(
+            base_url=service_config["base_url"],
+            headers=service_config["headers"],
+            timeout=service_config["timeout"],
+        )
+
+    def _build_mqtt_service(self, service_config: dict) -> MQTTService:
+        return MQTTService(
+            host=service_config["mqtt_broker_host"],
+            port=service_config["mqtt_broker_port"],
+            topic=service_config["mqtt_topic"],
+            client_id=service_config["mqtt_client_id"],
+            username=service_config["mqtt_username"],
+            password=service_config["mqtt_password"],
         )
 
     def create_ttf_service(self, session: Session) -> TTFService:
         """Create a TTF service — caller manages the session."""
         repo = PostgresTTFRepository(session)
-        return TTFService(repo=repo, weather_service=self.weather_service)
+        return TTFService(
+            repo=repo,
+            weather_service=self.weather_service,
+            mqtt_service=self.mqtt_service,
+        )
 
 
 factory: ServiceFactory | None = None
@@ -35,13 +54,23 @@ def get_factory() -> ServiceFactory:
     if factory is None:
         factory = ServiceFactory(
             database_url=config("DATABASE_URL"),
-            weather_config={
-                "base_url": weather_static.met_base_url,
-                "headers": weather_static.met_required_headers,
-                "timeout": 10,
-            },
+            service_config=_build_service_config(),
         )
     return factory
+
+
+def _build_service_config() -> dict:
+    return {
+        "base_url": weather_static.met_base_url,
+        "headers": weather_static.met_required_headers,
+        "timeout": 10,
+        "mqtt_broker_host": config("MQTT_BROKER_HOST", default="mqtt"),
+        "mqtt_broker_port": config("MQTT_BROKER_PORT", default=1883, cast=int),
+        "mqtt_topic": config("MQTT_TOPIC", default="firebuster/fire-risk"),
+        "mqtt_client_id": config("MQTT_CLIENT_ID", default="firebuster-api"),
+        "mqtt_username": config("MQTT_USERNAME", default=""),
+        "mqtt_password": config("MQTT_PASSWORD", default=""),
+    }
 
 
 def get_ttf_service():

--- a/app/services/mqtt/__init__.py
+++ b/app/services/mqtt/__init__.py
@@ -1,0 +1,1 @@
+from app.services.mqtt.mqtt_service import MQTTService

--- a/app/services/mqtt/mqtt_service.py
+++ b/app/services/mqtt/mqtt_service.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import json
+import logging
 
 import paho.mqtt.client as mqtt
 
 from app.models.ttf_result import TTFResult
+
+
+logger = logging.getLogger(__name__)
 
 
 class MQTTService:
@@ -55,9 +59,9 @@ class MQTTService:
         finally:
             try:
                 client.loop_stop()
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("Ignoring MQTT loop_stop cleanup error: %s", exc, exc_info=True)
             try:
                 client.disconnect()
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("Ignoring MQTT disconnect cleanup error: %s", exc, exc_info=True)

--- a/app/services/mqtt/mqtt_service.py
+++ b/app/services/mqtt/mqtt_service.py
@@ -1,0 +1,63 @@
+"""Minimal MQTT publisher for fire-risk events."""
+
+from __future__ import annotations
+
+import json
+
+import paho.mqtt.client as mqtt
+
+from app.models.ttf_result import TTFResult
+
+
+class MQTTService:
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        topic: str,
+        client_id: str,
+        username: str = "",
+        password: str = "",
+    ):
+        self.host = host
+        self.port = port
+        self.topic = topic
+        self.client_id = client_id
+        self.username = username
+        self.password = password
+
+    def publish_fire_risk(self, result: TTFResult) -> None:
+        client = mqtt.Client(client_id=self.client_id, protocol=mqtt.MQTTv311)
+
+        if self.username:
+            client.username_pw_set(self.username, self.password)
+
+        try:
+            client.connect(self.host, self.port, keepalive=60)
+            client.loop_start()
+
+            payload = {
+                "event_type": "fire_risk.calculated",
+                **result.model_dump(mode="json"),
+            }
+
+            message_info = client.publish(
+                self.topic,
+                json.dumps(payload),
+                qos=1,
+            )
+            message_info.wait_for_publish()
+
+            if message_info.rc != mqtt.MQTT_ERR_SUCCESS:
+                raise RuntimeError("MQTT publish returned a failure status")
+        except Exception as exc:
+            raise RuntimeError("Failed to publish fire-risk message") from exc
+        finally:
+            try:
+                client.loop_stop()
+            except Exception:
+                pass
+            try:
+                client.disconnect()
+            except Exception:
+                pass

--- a/app/services/ttf/ttf_service.py
+++ b/app/services/ttf/ttf_service.py
@@ -24,45 +24,51 @@ class TTFService:
         weather_service: Service instance for fetching weather data
     """
 
-    def __init__(self, repo, weather_service):
+    def __init__(self, repo, weather_service, mqtt_service=None):
         self.repo = repo
         self.weather_service = weather_service
+        self.mqtt_service = mqtt_service
 
     def get(self, lat: float, lon: float) -> TTFResult:
-        """Get TTF calculation results for specific coordinates.
-
-        This method first checks for cached results in the repository. If no
-        cached data exists, it fetches fresh weather data, calculates TTF values,
-        stores the result, and returns it.
-
-        Args:
-            lat: Latitude coordinate (decimal degrees, -90 to 90)
-            lon: Longitude coordinate (decimal degrees, -180 to 180)
-
-        Returns:
-            TTFResult: Object containing TTF calculations and metadata including:
-                - latitude: The requested latitude
-                - longitude: The requested longitude
-                - calculated_at: UTC timestamp of calculation
-                - ttf_points: List of combined weather data and TTF values
-        """
-        cached = self.repo.get(lat, lon)
+        cached = self._get_cached_result(lat, lon)
         if cached:
             return cached
 
-        try:
-            data_csv = self.weather_service.get_weather_at_location(lat, lon)
-        except Exception:
-            raise HTTPException(status_code=503, detail="Failed to fetch weather data")
+        data_csv = self._fetch_weather_csv(lat, lon)
+        result = self._build_ttf_result(lat, lon, data_csv)
 
+        self.repo.save(result)
+        self._publish_fire_risk(result)
+
+        return result
+
+    def _get_cached_result(self, lat: float, lon: float) -> TTFResult | None:
+        return self.repo.get(lat, lon)
+
+    def _fetch_weather_csv(self, lat: float, lon: float) -> str:
+        try:
+            return self.weather_service.get_weather_at_location(lat, lon)
+        except Exception as exc:
+            raise HTTPException(status_code=503, detail="Failed to fetch weather data") from exc
+
+    def _build_ttf_result(self, lat: float, lon: float, data_csv: str) -> TTFResult:
         ttf_points = TTFCalculator.calculate_from_csv(data_csv)
 
-        result = TTFResult(
+        return TTFResult(
             latitude=lat,
             longitude=lon,
             calculated_at=datetime.now(timezone.utc),
             ttf_points=[p.model_dump(mode="json") for p in ttf_points],
         )
 
-        self.repo.save(result)
-        return result
+    def _publish_fire_risk(self, result: TTFResult) -> None:
+        if self.mqtt_service is None:
+            return
+
+        try:
+            self.mqtt_service.publish_fire_risk(result)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=503,
+                detail="Failed to publish fire-risk message",
+            ) from exc

--- a/app/services/ttf/ttf_service.py
+++ b/app/services/ttf/ttf_service.py
@@ -37,8 +37,8 @@ class TTFService:
         data_csv = self._fetch_weather_csv(lat, lon)
         result = self._build_ttf_result(lat, lon, data_csv)
 
-        self.repo.save(result)
         self._publish_fire_risk(result)
+        self.repo.save(result)
 
         return result
 

--- a/compose.yml
+++ b/compose.yml
@@ -11,8 +11,22 @@ services:
       server_url: ${server_url}
       realm: ${realm}
       DATABASE_URL: ${FIREBUSTER_DB_URL}
+      MQTT_BROKER_HOST: ${MQTT_BROKER_HOST:-mqtt}
+      MQTT_BROKER_PORT: ${MQTT_BROKER_PORT:-1883}
+      MQTT_TOPIC: ${MQTT_TOPIC:-firebuster/fire-risk}
+      MQTT_CLIENT_ID: ${MQTT_CLIENT_ID:-firebuster-api}
+      MQTT_USERNAME: ${MQTT_USERNAME:-}
+      MQTT_PASSWORD: ${MQTT_PASSWORD:-}
     depends_on:
       - keycloak
+      - mqtt
+
+  mqtt:
+    image: eclipse-mosquitto:2
+    ports:
+      - "1883:1883"
+    volumes:
+      - ./mqtt/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
 
   keycloak:
     image: quay.io/keycloak/keycloak:latest

--- a/mqtt/mosquitto.conf
+++ b/mqtt/mosquitto.conf
@@ -1,0 +1,3 @@
+listener 1883
+allow_anonymous true
+persistence false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "fastapi-security>=0.1.0",
     "fastapi[standard]>=0.128.2",
     "frcm",
+    "paho-mqtt>=2.1.0",
     "pandas>=3.0.1",
     "requests>=2.32.0",
     "python-decouple>=3.8",

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -1,0 +1,76 @@
+import json
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import Mock, patch
+
+from app.models.ttf_result import TTFResult
+from app.services.mqtt.mqtt_service import MQTTService
+
+
+class TestMQTTService(unittest.TestCase):
+    @patch("app.services.mqtt.mqtt_service.mqtt.Client")
+    def test_publish_fire_risk_publishes_json_payload(self, mock_client_class):
+        client = Mock()
+        mock_client_class.return_value = client
+
+        publish_info = Mock()
+        publish_info.rc = 0
+        publish_info.wait_for_publish.return_value = None
+        client.publish.return_value = publish_info
+
+        service = MQTTService(
+            host="mqtt",
+            port=1883,
+            topic="firebuster/fire-risk",
+            client_id="firebuster-api",
+        )
+
+        result = TTFResult(
+            latitude=60.0,
+            longitude=5.0,
+            calculated_at=datetime(2026, 4, 14, 12, 0, tzinfo=timezone.utc),
+            ttf_points=[{"timestamp": "2026-04-14T12:00:00Z", "ttf": 42.0}],
+        )
+
+        service.publish_fire_risk(result)
+
+        client.connect.assert_called_once_with("mqtt", 1883, keepalive=60)
+        client.loop_start.assert_called_once()
+        client.publish.assert_called_once()
+        client.loop_stop.assert_called_once()
+        client.disconnect.assert_called_once()
+
+        topic, payload = client.publish.call_args.args[:2]
+        self.assertEqual("firebuster/fire-risk", topic)
+
+        payload_data = json.loads(payload)
+        self.assertEqual("fire_risk.calculated", payload_data["event_type"])
+        self.assertEqual(60.0, payload_data["latitude"])
+        self.assertEqual(5.0, payload_data["longitude"])
+
+    @patch("app.services.mqtt.mqtt_service.mqtt.Client")
+    def test_publish_fire_risk_raises_on_publish_failure(self, mock_client_class):
+        client = Mock()
+        mock_client_class.return_value = client
+
+        publish_info = Mock()
+        publish_info.rc = 1
+        publish_info.wait_for_publish.return_value = None
+        client.publish.return_value = publish_info
+
+        service = MQTTService(
+            host="mqtt",
+            port=1883,
+            topic="firebuster/fire-risk",
+            client_id="firebuster-api",
+        )
+
+        result = TTFResult(
+            latitude=60.0,
+            longitude=5.0,
+            calculated_at=datetime(2026, 4, 14, 12, 0, tzinfo=timezone.utc),
+            ttf_points=[{"timestamp": "2026-04-14T12:00:00Z", "ttf": 42.0}],
+        )
+
+        with self.assertRaises(RuntimeError):
+            service.publish_fire_risk(result)

--- a/tests/test_ttf_service.py
+++ b/tests/test_ttf_service.py
@@ -1,0 +1,79 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from fastapi import HTTPException
+
+from app.services.ttf.ttf_service import TTFService
+
+
+class TestTTFServiceMQTT(unittest.TestCase):
+    @patch("app.services.ttf.ttf_service.TTFCalculator.calculate_from_csv")
+    def test_get_publishes_fire_risk_after_save(self, mock_calculate):
+        point = Mock()
+        point.model_dump.return_value = {
+            "timestamp": "2026-04-14T12:00:00Z",
+            "temperature": 10.0,
+            "humidity": 60.0,
+            "wind_speed": 3.0,
+            "ttf": 42.0,
+        }
+        mock_calculate.return_value = [point]
+
+        repo = Mock()
+        repo.get.return_value = None
+        weather_service = Mock()
+        weather_service.get_weather_at_location.return_value = (
+            "timestamp,temperature,humidity,wind_speed\n"
+            "2026-04-14T12:00:00Z,10,60,3\n"
+            "2026-04-14T13:00:00Z,11,59,4\n"
+        )
+        mqtt_service = Mock()
+
+        service = TTFService(
+            repo=repo,
+            weather_service=weather_service,
+            mqtt_service=mqtt_service,
+        )
+
+        result = service.get(60.0, 5.0)
+
+        repo.save.assert_called_once()
+        mqtt_service.publish_fire_risk.assert_called_once_with(result)
+        self.assertEqual(60.0, result.latitude)
+        self.assertEqual(5.0, result.longitude)
+        self.assertEqual(1, len(result.ttf_points))
+
+    @patch("app.services.ttf.ttf_service.TTFCalculator.calculate_from_csv")
+    def test_get_raises_when_mqtt_publish_fails(self, mock_calculate):
+        point = Mock()
+        point.model_dump.return_value = {
+            "timestamp": "2026-04-14T12:00:00Z",
+            "temperature": 10.0,
+            "humidity": 60.0,
+            "wind_speed": 3.0,
+            "ttf": 42.0,
+        }
+        mock_calculate.return_value = [point]
+
+        repo = Mock()
+        repo.get.return_value = None
+        weather_service = Mock()
+        weather_service.get_weather_at_location.return_value = (
+            "timestamp,temperature,humidity,wind_speed\n"
+            "2026-04-14T12:00:00Z,10,60,3\n"
+            "2026-04-14T13:00:00Z,11,59,4\n"
+        )
+        mqtt_service = Mock()
+        mqtt_service.publish_fire_risk.side_effect = RuntimeError("broker down")
+
+        service = TTFService(
+            repo=repo,
+            weather_service=weather_service,
+            mqtt_service=mqtt_service,
+        )
+
+        with self.assertRaises(HTTPException) as context:
+            service.get(60.0, 5.0)
+
+        self.assertEqual(503, context.exception.status_code)
+        repo.save.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -527,6 +527,7 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "fastapi-security" },
     { name = "frcm" },
+    { name = "paho-mqtt" },
     { name = "pandas" },
     { name = "psycopg2-binary" },
     { name = "python-decouple" },
@@ -548,6 +549,7 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.128.2" },
     { name = "fastapi-security", specifier = ">=0.1.0" },
     { name = "frcm", git = "https://github.com/selabhvl/dynamic-frcm-simple.git" },
+    { name = "paho-mqtt", specifier = ">=2.1.0" },
     { name = "pandas", specifier = ">=3.0.1" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "python-decouple", specifier = ">=3.8" },
@@ -991,6 +993,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "paho-mqtt"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/15/0a6214e76d4d32e7f663b109cf71fb22561c2be0f701d67f93950cd40542/paho_mqtt-2.1.0.tar.gz", hash = "sha256:12d6e7511d4137555a3f6ea167ae846af2c7357b10bc6fa4f7c3968fc1723834", size = 148848, upload-time = "2024-04-29T19:52:55.591Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/cb/00451c3cf31790287768bb12c6bec834f5d292eaf3022afc88e14b8afc94/paho_mqtt-2.1.0-py3-none-any.whl", hash = "sha256:6db9ba9b34ed5bc6b6e3812718c7e06e2fd7444540df2455d2c51bd58808feee", size = 67219, upload-time = "2024-04-29T19:52:48.345Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces MQTT publishing for fire-risk calculation events. It adds a new `MQTTService` for publishing fire-risk results to an MQTT broker, updates the `TTFService` to publish results after calculation. Unit tests are included for the new functionality.

**MQTT integration and service changes:**

* Added a new `MQTTService` class (`app/services/mqtt/mqtt_service.py`) for publishing fire-risk calculation results to an MQTT broker.
* Updated `TTFService` to use `MQTTService` for publishing fire-risk events after saving results.
* Refactored `ServiceFactory` to instantiate and provide `MQTTService`, and updated service configuration to include MQTT settings.
* Added MQTT configuration to `.env.example` and Docker Compose (`compose.yml`), and included a Mosquitto MQTT broker service with a basic configuration file (`mqtt/mosquitto.conf`). 

**Dependencies and testing:**

* Added the `paho-mqtt` library to project dependencies for MQTT support.
* Implemented unit tests for `MQTTService` and for the MQTT publishing workflow in `TTFService`, covering both successful and failure scenarios.